### PR TITLE
Support strictNullChecks by adding type to generated process function

### DIFF
--- a/lib/js_rails_routes/language/typescript.rb
+++ b/lib/js_rails_routes/language/typescript.rb
@@ -11,7 +11,7 @@ module JSRailsRoutes
         type Params<Keys extends string> = { [key in Keys]: Value } & Record<string, Value>
         function process(route: string, params: Record<string, Value> | undefined, keys: string[]): string {
           if (!params) return route
-          var query = [];
+          var query: string[] = [];
           for (var param in params) if (params.hasOwnProperty(param)) {
             if (keys.indexOf(param) === -1) {
               query.push(param + "=" + encodeURIComponent(params[param].toString()));

--- a/spec/js_rails_routes/language/typescript_spec.rb
+++ b/spec/js_rails_routes/language/typescript_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe JSRailsRoutes::Language::TypeScript do
         type Params<Keys extends string> = { [key in Keys]: Value } & Record<string, Value>
         function process(route: string, params: Record<string, Value> | undefined, keys: string[]): string {
           if (!params) return route
-          var query = [];
+          var query: string[] = [];
           for (var param in params) if (params.hasOwnProperty(param)) {
             if (keys.indexOf(param) === -1) {
               query.push(param + "=" + encodeURIComponent(params[param].toString()));


### PR DESCRIPTION
When you specify strictNullChecks to true in compilerOptions for tsconfig, `query` variable inside the generated `process` function is considered as an array of never, which expects the arguments to be never, but is actually a string. 

I have fixed this by adding string type to the array.