### PR TITLE
Update corporate name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 
 ### Changed
 - Update corporate name from Increments Inc. to Qiita Inc.
+- Update gem authors and emails in gemspec file
 
 ## [0.10.1] - 2020-03-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 
 ## [Unreleased]
 
+### Changed
+- Update corporate name from Increments Inc. to Qiita Inc.
+
 ## [0.10.1] - 2020-03-09
 ### Fixed
 - Improved TypeScript typing

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 Increments Inc.
+Copyright (c) 2018 Qiita Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/js_rails_routes.gemspec
+++ b/js_rails_routes.gemspec
@@ -7,8 +7,8 @@ require 'js_rails_routes/version'
 Gem::Specification.new do |spec|
   spec.name            = 'js_rails_routes'
   spec.version         = JSRailsRoutes::VERSION
-  spec.authors         = ['Yuku Takahashi']
-  spec.email           = ['yuku@qiita.com']
+  spec.authors         = ['Qiita Inc.']
+  spec.email           = ['engineers@qiita.com']
   spec.summary         = 'Generate a ES6 module that contains Rails routes.'
   spec.homepage        = 'https://github.com/increments/js_rails_routes'
   spec.license         = 'MIT'


### PR DESCRIPTION
## What

- Our corporate name has changed from Increments Inc. to Qiita Inc.

## Reference

 - [Notice of Corporate Name and Headquarters Location Change - Qiita Inc.](https://corp.qiita.com/releases/2021/12/changed-company-name/)