### PR TITLE
Add eslint-disable comment not to affect eslint format

### DIFF
--- a/lib/js_rails_routes/generator.rb
+++ b/lib/js_rails_routes/generator.rb
@@ -17,7 +17,11 @@ module JSRailsRoutes
     def generate(task)
       builder.build.each do |artifact|
         file_name = File.join(config.output_dir, artifact.file_name)
-        file_body = "// Don't edit manually. `rake #{task}` generates this file.\n#{artifact.body}"
+        file_body = <<~FILE_BODY.chomp
+          /* eslint-disable */
+          // Don't edit manually. `rake #{task}` generates this file.
+          #{artifact.body}
+        FILE_BODY
         writable.write(file_name, file_body)
       end
     end

--- a/spec/js_rails_routes_spec.rb
+++ b/spec/js_rails_routes_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe JSRailsRoutes do
         subject
 
         expect(File.read(app_root.join('app/assets/javascripts/rails-routes.js'))).to eq <<~JAVASCRIPT
+          /* eslint-disable */
           // Don't edit manually. `rake #{task}` generates this file.
           #{JSRailsRoutes::Language::JavaScript::PROCESS_FUNC}
           export function blogs_path(params) { return process('/blogs', params, []); }
@@ -55,6 +56,7 @@ RSpec.describe JSRailsRoutes do
         JAVASCRIPT
 
         expect(File.read(app_root.join('app/assets/javascripts/admin-routes.js'))).to eq <<~JAVASCRIPT
+          /* eslint-disable */
           // Don't edit manually. `rake #{task}` generates this file.
           #{JSRailsRoutes::Language::JavaScript::PROCESS_FUNC}
           export function notes_path(params) { return process('/notes', params, []); }
@@ -94,6 +96,7 @@ RSpec.describe JSRailsRoutes do
         subject
 
         expect(File.read(app_root.join('app/assets/javascripts/rails-routes.ts'))).to eq <<~TYPESCRIPT
+          /* eslint-disable */
           // Don't edit manually. `rake #{task}` generates this file.
           #{JSRailsRoutes::Language::TypeScript::PROCESS_FUNC}
           export function blogs_path(params?: Record<string, Value>) { return process('/blogs', params, []); }
@@ -107,6 +110,7 @@ RSpec.describe JSRailsRoutes do
         TYPESCRIPT
 
         expect(File.read(app_root.join('app/assets/javascripts/admin-routes.ts'))).to eq <<~TYPESCRIPT
+          /* eslint-disable */
           // Don't edit manually. `rake #{task}` generates this file.
           #{JSRailsRoutes::Language::TypeScript::PROCESS_FUNC}
           export function notes_path(params?: Record<string, Value>) { return process('/notes', params, []); }


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

## What
Now, generated files are affected by eslint formatter.
But, the files should not be formatted by default.
This PR is for avoiding eslint formatting.