### PR TITLE
Update Ubuntu Actions runner image from 18.04 to 20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-18.04', 'ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-20.04', 'ubuntu-latest', 'macos-latest']
         ruby: [2.6, 2.7, 3.0, 3.1]
         experimental: [false]
         include:


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

Update the Ubuntu Actions runner image from 18.04 to 20.04 as the Ubuntu 18.04 Actions runner image has been deprecated.
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/