### PR TITLE
Add support for parameters as Array

### DIFF
--- a/lib/js_rails_routes/language/javascript.rb
+++ b/lib/js_rails_routes/language/javascript.rb
@@ -11,7 +11,13 @@ module JSRailsRoutes
           var query = [];
           for (var param in params) if (Object.prototype.hasOwnProperty.call(params, param)) {
             if (keys.indexOf(param) === -1) {
-              query.push(param + "=" + encodeURIComponent(params[param]));
+              if (Array.isArray(params[param])) {
+                for (var value of params[param] as Value[]) {
+                  query.push(param + "[]=" + encodeURIComponent(value));
+                }
+              } else {
+                query.push(param + "=" + encodeURIComponent(params[param]));
+              }
             }
           }
           return query.length ? route + "?" + query.join("&") : route;

--- a/lib/js_rails_routes/language/typescript.rb
+++ b/lib/js_rails_routes/language/typescript.rb
@@ -7,14 +7,20 @@ module JSRailsRoutes
   module Language
     class TypeScript < JavaScript
       PROCESS_FUNC = <<~TYPESCRIPT
-        type Value = string | number
+        type Value = string | number | Value[]
         type Params<Keys extends string> = { [key in Keys]: Value } & Record<string, Value>
         function process(route: string, params: Record<string, Value> | undefined, keys: string[]): string {
           if (!params) return route
           var query: string[] = [];
           for (var param in params) if (Object.prototype.hasOwnProperty.call(params, param)) {
             if (keys.indexOf(param) === -1) {
-              query.push(param + "=" + encodeURIComponent(params[param].toString()));
+              if (Array.isArray(params[param])) {
+                for (var value of params[param] as Value[]) {
+                  query.push(param + "[]=" + encodeURIComponent(value.toString()));
+                }
+              } else {
+                query.push(param + "=" + encodeURIComponent(params[param].toString()));
+              }
             }
           }
           return query.length ? route + "?" + query.join("&") : route;

--- a/spec/js_rails_routes/language/javascript_spec.rb
+++ b/spec/js_rails_routes/language/javascript_spec.rb
@@ -14,7 +14,13 @@ RSpec.describe JSRailsRoutes::Language::JavaScript do
           var query = [];
           for (var param in params) if (Object.prototype.hasOwnProperty.call(params, param)) {
             if (keys.indexOf(param) === -1) {
-              query.push(param + "=" + encodeURIComponent(params[param]));
+              if (Array.isArray(params[param])) {
+                for (var value of params[param] as Value[]) {
+                  query.push(param + "[]=" + encodeURIComponent(value));
+                }
+              } else {
+                query.push(param + "=" + encodeURIComponent(params[param]));
+              }
             }
           }
           return query.length ? route + "?" + query.join("&") : route;

--- a/spec/js_rails_routes/language/typescript_spec.rb
+++ b/spec/js_rails_routes/language/typescript_spec.rb
@@ -10,14 +10,20 @@ RSpec.describe JSRailsRoutes::Language::TypeScript do
 
     it 'returns a typescript function' do
       expect(subject).to eq <<~TYPESCRIPT
-        type Value = string | number
+        type Value = string | number | Value[]
         type Params<Keys extends string> = { [key in Keys]: Value } & Record<string, Value>
         function process(route: string, params: Record<string, Value> | undefined, keys: string[]): string {
           if (!params) return route
           var query: string[] = [];
           for (var param in params) if (Object.prototype.hasOwnProperty.call(params, param)) {
             if (keys.indexOf(param) === -1) {
-              query.push(param + "=" + encodeURIComponent(params[param].toString()));
+              if (Array.isArray(params[param])) {
+                for (var value of params[param] as Value[]) {
+                  query.push(param + "[]=" + encodeURIComponent(value.toString()));
+                }
+              } else {
+                query.push(param + "=" + encodeURIComponent(params[param].toString()));
+              }
             }
           }
           return query.length ? route + "?" + query.join("&") : route;


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->


https://edgeguides.rubyonrails.org/action_controller_overview.html#hash-and-array-parameters

This pull request introduces an enhancement to the js_rails_routes library by adding support for array parameters in URLs, aligning with the Ruby on Rails guideline for handling hash and array parameters. 