### PR TITLE
Bump ci environments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-latest', 'macos-latest']
-        ruby: [2.6, 2.7, 3.0, 3.1]
+        os: ['ubuntu-22.04', 'ubuntu-latest', 'macos-latest']
+        ruby: [3.2, 3.3, 3.4]
         experimental: [false]
         include:
           - os: 'ubuntu-latest'


### PR DESCRIPTION
# What

Closes https://github.com/increments/js_rails_routes/issues/43

- Remove deprecated environments os and ruby

# Refs

- https://docs.github.com/ja/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#%E3%83%91%E3%83%96%E3%83%AA%E3%83%83%E3%82%AF-%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E6%A8%99%E6%BA%96%E3%81%AE-github-%E3%81%A7%E3%83%9B%E3%82%B9%E3%83%88%E3%81%95%E3%82%8C%E3%81%9F%E3%83%A9%E3%83%B3%E3%83%8A%E3%83%BC
- https://www.ruby-lang.org/en/downloads/branches/

<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
