### PR TITLE
Add CODEOWNERS to /js_rails_routes.gemspec

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # package-ecosystem: bundler, directories: /
 /Gemfile @increments/shared-dev-group
 /Gemfile.lock @increments/shared-dev-group
+/js_rails_routes.gemspec @increments/shared-dev-group
 
 # package-ecosystem: github-actions, directories: /
 /.github/workflows @increments/shared-dev-group


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

## What
- Add codeowners to /js_rails_routes.gemspec

## Why

- Without reviewer created by dependabot when only change `/js_rails_routes.gemspec`
    - ex: https://github.com/increments/js_rails_routes/pull/57