### PR TITLE
Remove codeclimate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,13 +35,3 @@ jobs:
           bundler-cache: true
       - run: |
           bundle exec rake
-        if: matrix.os == 'macos-latest'
-      - name: Test & publish code coverage
-        uses: paambaati/codeclimate-action@f429536ee076d758a24705203199548125a28ca7 # v9.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-          GIT_BRANCH: ${{ steps.branch-name.outputs.current_branch }}
-          GIT_COMMIT_SHA: ${{ github.sha }}
-        with:
-          coverageCommand: bundle exec rake
-        if: matrix.os != 'macos-latest'

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Gem](https://img.shields.io/gem/v/js_rails_routes.svg?maxAge=2592000)](https://rubygems.org/gems/js_rails_routes)
 ![Build Status](https://github.com/increments/js_rails_routes/actions/workflows/test.yml/badge.svg?branch=master)
-[![Code Climate](https://codeclimate.com/github/increments/js_rails_routes/badges/gpa.svg)](https://codeclimate.com/github/increments/js_rails_routes)
-[![Test Coverage](https://codeclimate.com/github/increments/js_rails_routes/badges/coverage.svg)](https://codeclimate.com/github/increments/js_rails_routes/coverage)
 [![license](https://img.shields.io/github/license/increments/js_rails_routes.svg?maxAge=2592000)](https://github.com/increments/js_rails_routes/blob/master/LICENSE)
 
 Generate a ES6 module that contains Rails routes.

--- a/js_rails_routes.gemspec
+++ b/js_rails_routes.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rails', '>= 6.0'
   spec.add_development_dependency 'bundler', '>= 1.16'
-  spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.8'
   spec.add_development_dependency 'rubocop', '~> 1.27.0'


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
## What

- Remove use codeclimate

## How

- Remove codeclimate badge from README
- Uninstall codeclimate-test-reporter gem
- Remove codeclimate CI

## Why
- Code Climate API was disabled
    - https://docs.qlty.sh/migration/guide