### PR TITLE
Drop ruby verison support less than 3.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,15 +7,15 @@ AllCops:
   TargetRubyVersion: 3.2
   NewCops: enable
 
-Metrics/LineLength:
-  Max: 120
+Style/Documentation:
+  Enabled: false
 
-Metrics/BlockLength:
+Layout/BlockLength:
   Exclude:
   - 'spec/**/*'
 
-Style/Documentation:
-  Enabled: false
+Layout/LineLength:
+  Max: 120
 
 Layout/MultilineMethodCallIndentation:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.2
   NewCops: enable
 
 Metrics/LineLength:

--- a/js_rails_routes.gemspec
+++ b/js_rails_routes.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license         = 'MIT'
   spec.files           = `git ls-files -z`.split("\x0")
   spec.require_paths   = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.2.0'
 
   spec.add_dependency 'rails', '>= 6.0'
   spec.add_development_dependency 'bundler', '>= 1.16'

--- a/lib/js_rails_routes.rb
+++ b/lib/js_rails_routes.rb
@@ -8,7 +8,7 @@ require 'js_rails_routes/language/javascript'
 require 'js_rails_routes/language/typescript'
 
 module JSRailsRoutes
-  PARAM_REGEXP = %r{:(.*?)(/|$)}.freeze
+  PARAM_REGEXP = %r{:(.*?)(/|$)}
 
   module_function
 

--- a/spec/js_rails_routes/builder_spec.rb
+++ b/spec/js_rails_routes/builder_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe JSRailsRoutes::Builder do
 
     it 'returns an array of artifacts' do
       expect(subject).to contain_exactly(
-        an_object_having_attributes(engine_name: rails_route_set.name, body: body),
-        an_object_having_attributes(engine_name: engine_route_set.name, body: body)
+        an_object_having_attributes(engine_name: rails_route_set.name, body:),
+        an_object_having_attributes(engine_name: engine_route_set.name, body:)
       )
       expect(language).to have_received(:handle_route_set).twice
     end

--- a/spec/js_rails_routes/generator_spec.rb
+++ b/spec/js_rails_routes/generator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe JSRailsRoutes::Generator do
-  subject(:generator) { described_class.new(builder, writable: writable) }
+  subject(:generator) { described_class.new(builder, writable:) }
 
   include_context 'run in a sandbox'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ SimpleCov.start
 require 'rails/all'
 require 'js_rails_routes'
 
-Dir[File.expand_path('support/**/*.rb', __dir__)].sort.each { |f| require f }
+Dir[File.expand_path('support/**/*.rb', __dir__)].each { |f| require f }
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
## What
- Drop support less than 3.2

## How

- CHange require version to ruby (2.6 -> 3.2)
- Change rubocop target version
- Fix based on rubocop

## Why

- Stop support ruby version less than from 3.2
    - https://www.ruby-lang.org/en/downloads/branches/