### PR TITLE
Introduce qlty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,18 @@ jobs:
           bundler-cache: true
       - run: |
           bundle exec rake
+
+  qlty:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: ruby/setup-ruby@13e7a03dc3ac6c3798f4570bfead2aed4d96abfb # v1.244.0
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - name: Test
+        run: bundle exec rspec
+      - uses: qltysh/qlty-action/coverage@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
+        with:
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: ./coverage/coverage.json

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ gem 'rspec', '~> 3.8'
 gem 'rubocop', '~> 1.81.1'
 gem 'rubocop-rspec', '~> 3.0'
 gem 'simplecov', '!= 0.18.0', '!= 0.18.1', '!= 0.18.2', '!= 0.18.3', '!= 0.18.4', '!= 0.18.5', '!= 0.19.0', '!= 0.19.1', '~> 0.22.0' # rubocop:disable Metrics/LineLength
+gem 'simplecov_json_formatter', '~> 0.1.4'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Gem](https://img.shields.io/gem/v/js_rails_routes.svg?maxAge=2592000)](https://rubygems.org/gems/js_rails_routes)
 ![Build Status](https://github.com/increments/js_rails_routes/actions/workflows/test.yml/badge.svg?branch=master)
 [![license](https://img.shields.io/github/license/increments/js_rails_routes.svg?maxAge=2592000)](https://github.com/increments/js_rails_routes/blob/master/LICENSE)
+[![Maintainability](https://qlty.sh/gh/increments/projects/js_rails_routes/maintainability.svg)](https://qlty.sh/gh/increments/projects/js_rails_routes)
+[![Code Coverage](https://qlty.sh/gh/increments/projects/js_rails_routes/coverage.svg)](https://qlty.sh/gh/increments/projects/js_rails_routes)
 
 Generate a ES6 module that contains Rails routes.
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,16 @@
 $LOAD_PATH << File.expand_path('../lib', __dir__)
 
 require 'simplecov'
-SimpleCov.start
+require 'simplecov_json_formatter'
+
+SimpleCov.start do
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::JSONFormatter,
+    SimpleCov::Formatter::HTMLFormatter
+  ]
+
+  add_filter '/spec/'
+end
 
 require 'rails/all'
 require 'js_rails_routes'


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
## What

- Calculate and upload code coverage data to qlty during CI
- Make code coverage and Maintainability viewable from the README

## How

- Install `simplecov_json_formatter`
- Change the coverage output format to JSON
- Implement the coverage action from qlty
- Add a badge to the README


## Why

- The Code Climate API has been disabled
    - https://docs.qlty.sh/migration/guide

## REF

- https://github.com/increments/js_rails_routes/pull/70